### PR TITLE
Feature: No Pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
-## PHP Starter Template
+# The Holiday Wishlist
 
-### Setup
+## Setup
 1. run `npm install` to install dependencies
 2. run `gulp run setup` to pull in most recent bootstrap files
 3. Create a database with at least one table **users** (Use `database.sql` to set up a basic table)
 4. Enter database credentials in `private/db_credentials.php`
 
 
-### Development
+## Development
 run `npm run dev`
 
-### Build
+## Build
 run `npm run build`
 
-### Future Ideas
-- Ability to add amazon list links (or other sites) to profile
+## Versioning
 
-### Troubleshooting
+### v2.0.0
+- Added a new no_pair feature which checks database to make sure that specified people can't be paired up
+- Added a new no_pair feature which makes sure two people can't be paired up again for at least 3 years
+
+## Future Ideas
+- Ability to add amazon list links (or other sites) to profile
+- Add kids vs. adults exchanges
+- Add people who can be viewers only. They can add their items but can't be part of the exchange
+- Make it multi-group or multi-family and make your wishlist of items carry across if you are in multiple groups
+
+## Troubleshooting
 There are some common issues when installing this on your server.
 1. Wrong database credentials
 Check the `db_credentials.php` file in the `private` folder

--- a/html/exchange/form_fields.php
+++ b/html/exchange/form_fields.php
@@ -4,77 +4,58 @@
 if (!isset($exchange)) {
     redirect_to(url_for('/exchange/index.php'));
 }
-$already_matched = [];
-foreach ($exchange as $match) {
-    $already_matched[$match->user_id] = $match->match_id;
-}
-// var_dump($already_matched);
 
-$match_list = [];
-foreach ($already_matched as $i) {
-    $u = User::find_by_id($i);
-    $match_list[] = $u->full_name();
-}
+$assignments = [];
+$remaining = $people;
 
+do {
+    $valid = true; // Assume the current shuffle will work
+    $assignments = [];
 
-$arr = [];
-foreach ($users as $user) {
-    // var_dump($user);
-    if (!in_array($user->id, $already_matched)) {
-        $arr[] = $user->id;
+    // Assign each person to the next in the list
+    for ($i = 0; $i < count($people); $i++) {
+        $assigner = $people[$i];
+        $assignee = $people[($i + 1) % count($people)]; // Circular assignment
+
+        if (!User::isValidAssignment($assigner, $assignee, $database, $year)) {
+            $valid = false;
+            shuffle($people); // Re-shuffle if invalid assignment
+            break;
+        }
+
+        $assignments[] = [$assigner, $assignee];
     }
-}
+} while (!$valid); // Repeat until a valid arrangement is found
 
-if (!empty($match_list)) {
-    ?>
-
-<p><b><?php echo implode("</b>, <b>", $match_list);?></b>
-	already have matches.</p>
-
-<?php
-}
-
-if (empty($arr)) {
-    return;
-} else { ?>
+?>
 
 <thead>
 	<th>Person</th>
 	<th>Match</th>
 </thead>
 <?php
-// var_dump($exchange);
-
-$res = [];
-    (shuffle($arr));
-
-    for ($i=0;$i<count($arr);$i++) {
-        $res[$arr[$i]] = $arr[$i+1];
-    }
-    $res[$arr[count($arr)-1]] = $arr[0];
-    // print_r($res);
     $i = 0;
-    foreach ($res as $key => $value) { ?>
-<?php $user = User::find_by_id($key);
-        $match = User::find_by_id($value); ?>
-<tr>
-	<td>
-		<input type="text"
-			name="exchange[<?php echo $i;?>][user_name]"
-			value="<?php echo $user->first_name; ?>" readonly />
-		<input type="hidden"
-			name="exchange[<?php echo $i;?>][user_id]"
-			value="<?php echo $user->id; ?>" />
-	</td>
-	<td>
-		<input type="text"
-			name="exchange[<?php echo $i;?>][match_name]"
-			value="<?php echo $match->first_name; ?>" readonly />
-		<input type="hidden"
-			name="exchange[<?php echo $i;?>][match_id]"
-			value="<?php echo $match->id; ?>" />
-	</td>
-</tr>
-<?php $i++; ?>
-<?php } ?>
-<?php } ?>
+    foreach ($assignments as $assignment) {  
+        $user = User::find_by_id($assignment[0]);
+        $match = User::find_by_id($assignment[1]); 
+?>
+        <tr>
+            <td>
+                <input type="text"
+                    name="exchange[<?php echo $i;?>][user_name]"
+                    value="<?php echo $user->first_name; ?>" readonly />
+                <input type="hidden"
+                    name="exchange[<?php echo $i;?>][user_id]"
+                    value="<?php echo $user->id; ?>" />
+            </td>
+            <td>
+                <input type="text"
+                    name="exchange[<?php echo $i;?>][match_name]"
+                    value="<?php echo $match->first_name; ?>" readonly />
+                <input type="hidden"
+                    name="exchange[<?php echo $i;?>][match_id]"
+                    value="<?php echo $match->id; ?>" />
+            </td>
+        </tr>
+    <?php $i++; ?>
+<?php } // end foreach ?>

--- a/html/exchange/index.php
+++ b/html/exchange/index.php
@@ -28,11 +28,11 @@ $years = Exchange::find_all_years();
 	<div class="row pt-5 justify-content-center">
 
 		<?php
-        $x=1;
+        $x = 1;
 foreach ($years as $year) {
     echo '<a href="' . url_for("/exchange/show.php?year=" . $year) . '">' . $year . '</a> ';
     if ($x < count($years)) {
-        echo ' | ';
+        echo '&nbsp;|&nbsp;';
     }
     $x++;
 } ?>

--- a/html/exchange/new.php
+++ b/html/exchange/new.php
@@ -13,6 +13,8 @@ $exchange = Exchange::find_by_year($year);
 
 if (is_post_request()) {
     // Create record using post parameters
+    $reset = Exchange::resetAssignments($year);
+    
     $args = $_POST['exchange'];
     var_dump($args);
     $year = '';
@@ -57,9 +59,9 @@ if (is_post_request()) {
 					<?php include('form_fields.php');?>
 
 				</table>
-				<?php if (!empty($arr)) { ?>
+				<?php // if (!empty($arr)) {?>
 				<button type="submit" class="btn btn-primary">Submit Names</button>
-				<?php } ?>
+				<?php // }?>
 			</form>
 		</div>
 

--- a/html/exchange/new.php
+++ b/html/exchange/new.php
@@ -5,6 +5,7 @@
 
 // Find all admins
 $users = User::find_all();
+$people = User::get_people($users);
 
 $year = date('Y');
 

--- a/html/users/form_fields.php
+++ b/html/users/form_fields.php
@@ -33,6 +33,23 @@ if (!isset($user)) {
 	<input type="password" name="user[confirm_password]" value="" class="form-control" id="inputPasswordConfirm">
 </div>
 <?php if ($admin->is_admin()) { ?>
+
+<div class="form-group">
+	<label for="type">Type</label>
+	<select class="form-control" id="type" name="user[type]">
+		<option value=""></option>
+		<?php
+    foreach (User::TYPE as $type_id => $type_name) {
+        ?>
+		<option value="<?php echo $type_id; ?>" <?php
+                                if ($user->type == $type_id) {
+                                    echo 'selected';
+                                }
+        ?>
+			><?php echo $type_name; ?></option>
+		<?php } ?>
+	</select>
+</div>
 <div class="form-group form-check">
 	<input type="hidden" name="user[is_admin]" value="0" />
 	<input type="checkbox" name="user[is_admin]" value="1" <?php if ($user->is_admin()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "holiday-wishlist",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"description": "Allow users to create wishlists for holidays and assign their secret Santa",
 	"main": "./html/index.php",
 	"scripts": {

--- a/private/classes/exchange.class.php
+++ b/private/classes/exchange.class.php
@@ -10,7 +10,7 @@ class Exchange extends DatabaseObject
     public $user_id;
     public $match_id;
 
-    public function __construct($args=[])
+    public function __construct($args = [])
     {
         $this->year = $args['year'] ?? date('Y');
         $this->user_id = $args['user_id'] ?? '';
@@ -61,6 +61,16 @@ class Exchange extends DatabaseObject
             $years[] = $r->year;
         }
         return $years;
+    }
+
+    public static function resetAssignments($year)
+    {
+
+        $stmt = self::$database->prepare("DELETE FROM exchange WHERE year = ?");
+        $stmt->bind_param("i", self::$database->escape_string($year));
+        $result = $stmt->execute();
+        return $result;
+
     }
 
     public function get_name($id)

--- a/private/classes/user.class.php
+++ b/private/classes/user.class.php
@@ -128,6 +128,52 @@ class User extends DatabaseObject
         }
     }
 
+    public static function get_people($users)
+    {
+
+        $people = [];
+        foreach ($users as $user) {
+            $people[] = $user->id;
+        }
+        shuffle($people);
+        return $people;
+
+    }
+
+    public static function isValidAssignment($assigner, $assignee, $conn, $currentYear)
+    {
+
+        $stmt = $conn->prepare("SELECT * FROM no_pair WHERE (person1 = ? AND person2 = ?) OR (person1 = ? AND person2 = ?)");
+        $stmt->bind_param("ssss", $assigner, $assignee, $assignee, $assigner);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        if ($result->num_rows > 0) {
+            return false;
+        }
+
+
+        $stmt = $conn->prepare("
+            SELECT * FROM exchange 
+            WHERE user_id = ? AND match_id = ?
+            AND year >= ?
+        ");
+        $thresholdYear = $currentYear - 2;
+        $stmt->bind_param("ssi", $assigner, $assignee, $thresholdYear);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        return $result->num_rows === 0;
+
+    }
+
+    public function type()
+    {
+        if ($this->type > 0) {
+            return self::TYPE[ $this->type ];
+        } else {
+            return 'Unknown';
+        }
+    }
+
     public function is_admin()
     {
         if ($this->is_admin == 1) {

--- a/private/classes/user.class.php
+++ b/private/classes/user.class.php
@@ -15,10 +15,15 @@ class User extends DatabaseObject
     public $password;
     public $confirm_password;
     protected $password_required = true;
-    protected $type;
+    public $type;
     protected $is_admin = false;
 
-    public function __construct($args=[])
+    public const TYPE = [
+        1 => 'Adult',
+        2 => 'Child'
+    ];
+
+    public function __construct($args = [])
     {
         $this->first_name = $args['first_name'] ?? '';
         $this->last_name = $args['last_name'] ?? '';
@@ -182,4 +187,6 @@ class User extends DatabaseObject
             return false;
         }
     }
+
+
 }


### PR DESCRIPTION
This new feature set solves the problem of people in the same household getting paired together as well as people getting the same name multiple years in a row.

We created a new table `no_pair` where I added the pairs of people who can't be together in the exchange. Then when creating the exchange we run a check on the no_pair table as well as look at past pairings before allowing two people to be paired together. 